### PR TITLE
When checking image file extension, ignore case

### DIFF
--- a/fileshandling/image.go
+++ b/fileshandling/image.go
@@ -82,7 +82,7 @@ func imageFromURL(URL string) (imageLib.Image, error) {
 
 func hasImageExtension(path string) bool {
 	for _, ext := range imageExtensions {
-		if strings.HasSuffix(path, ext) {
+		if strings.HasSuffix(strings.ToLower(path), ext) {
 			return true
 		}
 	}


### PR DESCRIPTION
I have lots of *.JPG files that were incorrectly identified as not having a image file extension.