### PR TITLE
Upload 5 files concurrently

### DIFF
--- a/cmd/gphotos-uploader-cli/main.go
+++ b/cmd/gphotos-uploader-cli/main.go
@@ -43,20 +43,20 @@ func startUploader(cmd *cobra.Command, args []string) {
 	defer db.Close()
 
 	// start file upload worker
-	doneUploading := upload.StartFileUploadWorker()
+	fileUploadsChan, doneUploading := upload.StartFileUploadWorker()
 	doneDeleting := fileshandling.StartDeletionsWorker()
 
 	// launch all folder upload jobs
 	for _, job := range uploaderConfig.Jobs {
 		folderUploadJob := upload.NewFolderUploadJob(&job, completeduploads.NewService(db), uploaderConfig.APIAppCredentials)
 
-		if err := folderUploadJob.Upload(); err != nil {
+		if err := folderUploadJob.Upload(fileUploadsChan); err != nil {
 			printError("Failed to upload folder %s: %v", job.SourceFolder, err)
 		}
 	}
 
 	// after we've run all the folder upload jobs we're done adding file upload jobs
-	upload.CloseFileUploadsChan()
+	close(fileUploadsChan)
 	// wait for all the uploads to be completed
 	<-doneUploading
 	fmt.Println("all uploads done")

--- a/fileshandling/file.go
+++ b/fileshandling/file.go
@@ -4,7 +4,6 @@ import (
 	"github.com/nmrshll/gphotos-uploader-cli/utils/filesystem"
 	"gopkg.in/h2non/filetype.v1"
 	filematchers "gopkg.in/h2non/filetype.v1/matchers"
-	filetypes "gopkg.in/h2non/filetype.v1/types"
 )
 
 //func fileBuffer(filePath string) (buf []byte, _ error) {
@@ -28,7 +27,7 @@ func IsImage(filePath string) bool {
 
 	kind, _ := filetype.Image(buf)
 
-	return kind != filetypes.Unknown && kind != filematchers.TypePsd && kind != filematchers.TypeTiff && kind != filematchers.TypeCR2
+	return kind != filetype.Unknown && kind != filematchers.TypePsd && kind != filematchers.TypeTiff && kind != filematchers.TypeCR2
 }
 
 // IsVideo asserts file at filePath is an image

--- a/upload/folderUploadJob.go
+++ b/upload/folderUploadJob.go
@@ -90,7 +90,7 @@ func authenticate(folderUploadJob *FolderUploadJob) (*gphotos.Client, error) {
 }
 
 // Upload uploads folder
-func (folderUploadJob *FolderUploadJob) Upload() error {
+func (folderUploadJob *FolderUploadJob) Upload(fileUploadsChan chan *FileUpload) error {
 	folderAbsolutePath, err := cp.AbsolutePath(folderUploadJob.SourceFolder)
 	if err != nil {
 		return err
@@ -139,7 +139,7 @@ func (folderUploadJob *FolderUploadJob) Upload() error {
 			}
 
 			// finally, add the file upload to the queue
-			QueueFileUpload(fileUpload)
+			fileUploadsChan <- fileUpload
 		}
 
 		return nil


### PR DESCRIPTION
## Benefits
- improved throughput
- uses `const uploadConcurrency = 5` to set limit

## Example Run
```
2019/01/28 22:44:21 Uploading DSC_0018.JPG
2019/01/28 22:44:22 Uploading DSC_0020.JPG
2019/01/28 22:44:22 Uploading DSC_0017.JPG
2019/01/28 22:44:22 Uploading DSC_0016.JPG
2019/01/28 22:44:22 Uploading DSC_0019.JPG
2019/01/28 22:44:28 DSC_0018.JPG uploaded successfully asxxxxxxRkquFB8zLGg6tXyA
2019/01/28 22:44:28 Marked as uploaded: xxxxx
2019/01/28 22:44:29 DSC_0016.JPG uploaded successfully as xxxxxx
2019/01/28 22:44:29 Marked as uploaded: xxxxxxx
2019/01/28 22:44:29 DSC_0017.JPG uploaded xxxxxxx
2019/01/28 22:44:29 Marked as uploaded: xxxxxxx
2019/01/28 22:44:30 DSC_0020.JPG uploaded successfully as Axxxxxx
2019/01/28 22:44:30 Marked as uploaded: xxxxxx
2019/01/28 22:44:30 DSC_0019.JPG uploaded successfully as xxxxx
```