### PR TITLE
h2non/filetype now on github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 # Binary releases
 /dist/
 /gphotos-uploader-cli
+cmd/gphotos-uploader-cli/gphotos-uploader-cli
+main
 
 # Tests files
 /coverage.txt

--- a/filetypes/file.go
+++ b/filetypes/file.go
@@ -4,11 +4,11 @@ import (
 	"io"
 	"os"
 
+	"github.com/h2non/filetype"
+	filematchers "github.com/h2non/filetype/matchers"
 	"github.com/juju/errors"
 	"github.com/nmrshll/gphotos-uploader-cli/utils/filesystem"
 	"github.com/pierrec/xxHash/xxHash32"
-	"gopkg.in/h2non/filetype.v1"
-	filematchers "gopkg.in/h2non/filetype.v1/matchers"
 )
 
 // IsImage asserts file at filePath is an image

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/fatih/color v1.7.0
 	github.com/godbus/dbus v4.1.0+incompatible // indirect
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
+	github.com/h2non/filetype v1.0.8
 	github.com/hashicorp/go-multierror v1.0.0 // indirect
 	github.com/juju/errors v0.0.0-20190207033735-e65537c515d7
 	github.com/mattn/go-colorable v0.0.9 // indirect
@@ -29,5 +30,4 @@ require (
 	golang.org/x/net v0.0.0-20181207154023-610586996380 // indirect
 	golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890
 	google.golang.org/api v0.0.0-20181213000619-1327b224df06
-	gopkg.in/h2non/filetype.v1 v1.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/godbus/dbus v4.1.0+incompatible h1:WqqLRTsQic3apZUK9qC5sGNfXthmPXzUZ7
 github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pOkfl+p/TAqKOfFu+7KPlMVpok/w=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/h2non/filetype v1.0.8 h1:le8gpf+FQA0/DlDABbtisA1KiTS0Xi+YSC/E8yY3Y14=
+github.com/h2non/filetype v1.0.8/go.mod h1:isekKqOuhMj+s/7r3rIeTErIRy4Rub5uBWHfvMusLMU=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=


### PR DESCRIPTION
## Changes:
* moved h2non/filetype to github
@davidmaxwaterman can you test this variant?  I've moved the dep over to github


## Testing
```
$ git clone git@github.com:tonymet/gphotos-uploader-cli.git --branch feature/fix-h2non-filetype
$ GO111MODULE=on go get .
```