### PR TITLE
Vendor google.golang.org/api/photoslibrary (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
-### Fixec
+### Changed
+- Add `google.golang.org/api/photoslibrary` as vendor library, due to [Google's announcement](https://code-review.googlesource.com/c/google-api-go-client/+/39951) (#53)
+### Fixed
 - Fix installation instructions (#72)
 
 ## 0.2.1 - 2019-06-18

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/nmrshll/gphotos-uploader-cli
 
+replace /google.golang.org/api/photoslibrary => ./vendor/google.golang.org/api/photoslibrary
+
 require (
 	cloud.google.com/go v0.34.0 // indirect
 	github.com/Nr90/imgsim v0.0.0-20180202144352-5caa057144b0
@@ -46,4 +48,3 @@ require (
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
 
-replace google.golang.org/api/photoslibrary => ./vendor/google.golang.org/api/photoslibrary

--- a/go.mod
+++ b/go.mod
@@ -47,4 +47,3 @@ require (
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
-


### PR DESCRIPTION
As It has been deeply discussed on #53 and it [was announced](https://code-review.googlesource.com/c/google-api-go-client/+/39951) by library maintainers. `google.golang.org/api/photoslibrary` is not online so it needs to be vendored.

I've downloaded [this version](https://raw.githubusercontent.com/influxdata/influxdata-operator/master/vendor/google.golang.org/api/photoslibrary/v1/photoslibrary-gen.go) to be used as vendor.

This is fixing #74 PR that was reverted.

Closes #53