### PR TITLE
Add skip folder feature

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ type APIAppCredentials struct {
 type FolderUploadJob struct {
 	Account           string
 	SourceFolder      string
+	SkipFolders       []string
 	MakeAlbums        MakeAlbums
 	DeleteAfterUpload bool
 	UploadVideos      bool
@@ -56,6 +57,7 @@ func defaultConfig() *Config {
 	job := FolderUploadJob{
 		Account:      "youremail@gmail.com",
 		SourceFolder: "~/folder/to/upload",
+		SkipFolders:  []string{"the_folder_name_you_want_to_skip"},
 		MakeAlbums: MakeAlbums{
 			Enabled: true,
 			Use:     "folderNames",
@@ -80,6 +82,9 @@ func (c Config) String() string {
     {
       account: %s
       sourceFolder: %s
+      skipFolders: [
+        %s
+      ]
       makeAlbums: {
         enabled: %t
         use: %s
@@ -95,6 +100,7 @@ func (c Config) String() string {
 		c.APIAppCredentials.ClientSecret,
 		c.Jobs[0].Account,
 		c.Jobs[0].SourceFolder,
+		c.Jobs[0].SkipFolders[0],
 		c.Jobs[0].MakeAlbums.Enabled,
 		c.Jobs[0].MakeAlbums.Use,
 		c.Jobs[0].DeleteAfterUpload,

--- a/upload/folderUploadJob.go
+++ b/upload/folderUploadJob.go
@@ -108,7 +108,7 @@ func (folderUploadJob *FolderUploadJob) Upload(fileUploadsChan chan<- *FileUploa
 			for _, v := range folderUploadJob.SkipFolders {
 				if v == filepath.Base(filePath) {
 					log.Printf("Folder is in the skip list: %s: skipping folder", filePath)
-					return nil
+					return filepath.SkipDir
 				}
 			}
 			if folderUploadJob.MakeAlbums.Enabled && folderUploadJob.MakeAlbums.Use == "folderNames" {

--- a/upload/folderUploadJob.go
+++ b/upload/folderUploadJob.go
@@ -105,6 +105,12 @@ func (folderUploadJob *FolderUploadJob) Upload(fileUploadsChan chan<- *FileUploa
 	currentPhotoAlbum := &photoslibrary.Album{}
 	errW := filepath.Walk(folderAbsolutePath, func(filePath string, info os.FileInfo, errP error) error {
 		if info.IsDir() {
+			for _, v := range folderUploadJob.SkipFolders {
+				if v == filepath.Base(filePath) {
+					log.Printf("Folder is in the skip list: %s: skipping folder", filePath)
+					return nil
+				}
+			}
 			if folderUploadJob.MakeAlbums.Enabled && folderUploadJob.MakeAlbums.Use == "folderNames" {
 				log.Printf("Entering Directory: %s", filePath)
 				currentPhotoAlbum, err = folderUploadJob.gphotosClient.GetOrCreateAlbumByName(filepath.Base(filePath))


### PR DESCRIPTION
There are some cache folders created by software automatically, such as my Synology NAS will create "@eadir" folder for cache.
So I added a skip folder config to avoid upload those cache image to google photo.