### PR TITLE
Remove special characters from token store service name

### DIFF
--- a/datastore/tokenstore/interface.go
+++ b/datastore/tokenstore/interface.go
@@ -2,6 +2,7 @@ package tokenstore
 
 import (
 	"errors"
+
 	"golang.org/x/oauth2"
 )
 
@@ -17,11 +18,10 @@ var (
 )
 
 const (
-	serviceName = "googlephotos-uploader-go-api"
+	serviceName = "gPhotosUploader"
 )
 
 type TokenManager interface {
 	StoreToken(email string, token *oauth2.Token) error
 	RetrieveToken(email string) (*oauth2.Token, error)
 }
-


### PR DESCRIPTION
This resolves https://github.com/nmrshll/gphotos-uploader-cli/issues/97

An less intrusive alternative for other unaffected backends may be to remove the `-` characters only for the `secret-service` backend.